### PR TITLE
Add experimental support for Pi 2/3 emulation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,11 +28,33 @@ RUN apt-get -y install python build-essential libglib2.0-dev libpixman-1-dev
 RUN apt-get -y install libfdt-dev zlib1g-dev
 # Not required or specified anywhere but supress build warnings
 RUN apt-get -y install flex bison
-RUN "qemu-${QEMU_VERSION}/configure" --static --target-list=arm-softmmu
+RUN "qemu-${QEMU_VERSION}/configure" --static --target-list=arm-softmmu,aarch64-softmmu
 RUN make -j$(nproc)
 
 RUN # Strip the binary, this gives a substantial size reduction!
-RUN strip "arm-softmmu/qemu-system-arm"
+RUN strip "arm-softmmu/qemu-system-arm" "aarch64-softmmu/qemu-system-aarch64"
+
+
+# Build stage for fatcat
+FROM debian:stable-slim AS fatcat-builder
+ARG FATCAT_VERSION=1.1.0
+ENV FATCAT_TARBALL="v${FATCAT_VERSION}.tar.gz"
+WORKDIR /fatcat
+
+RUN # Update package lists
+RUN apt-get update
+
+RUN # Pull source
+RUN apt-get -y install wget
+RUN wget "https://github.com/Gregwar/fatcat/archive/${FATCAT_TARBALL}"
+
+RUN # Extract source tarball
+RUN tar xvf "${FATCAT_TARBALL}"
+
+RUN # Build source
+RUN apt-get -y install build-essential cmake
+RUN cmake "fatcat-${FATCAT_VERSION}" -DCMAKE_CXX_FLAGS='-static'
+RUN make -j$(nproc)
 
 
 # Build the dockerpi VM image
@@ -42,6 +64,8 @@ ARG RPI_KERNEL_URL="https://github.com/dhruvvyas90/qemu-rpi-kernel/archive/afe41
 ARG RPI_KERNEL_CHECKSUM="295a22f1cd49ab51b9e7192103ee7c917624b063cc5ca2e11434164638aad5f4"
 
 COPY --from=qemu-system-arm-builder /qemu/arm-softmmu/qemu-system-arm /usr/local/bin/qemu-system-arm
+COPY --from=qemu-system-arm-builder /qemu/aarch64-softmmu/qemu-system-aarch64 /usr/local/bin/qemu-system-aarch64
+COPY --from=fatcat-builder /fatcat/fatcat /usr/local/bin/fatcat
 
 ADD $RPI_KERNEL_URL /tmp/qemu-rpi-kernel.zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage for qemu-system-arm
-FROM debian:stable-slim AS qemu-system-arm-builder
+FROM debian:stable-slim AS qemu-builder
 ARG QEMU_VERSION=4.2.0
 ENV QEMU_TARBALL="qemu-${QEMU_VERSION}.tar.xz"
 WORKDIR /qemu
@@ -37,8 +37,9 @@ RUN strip "arm-softmmu/qemu-system-arm" "aarch64-softmmu/qemu-system-aarch64"
 
 # Build stage for fatcat
 FROM debian:stable-slim AS fatcat-builder
-ARG FATCAT_VERSION=1.1.0
-ENV FATCAT_TARBALL="v${FATCAT_VERSION}.tar.gz"
+ARG FATCAT_VERSION=v1.1.0
+ARG FATCAT_CHECKSUM="303efe2aa73cbfe6fbc5d8af346d0f2c70b3f996fc891e8859213a58b95ad88c"
+ENV FATCAT_TARBALL="${FATCAT_VERSION}.tar.gz"
 WORKDIR /fatcat
 
 RUN # Update package lists
@@ -47,13 +48,14 @@ RUN apt-get update
 RUN # Pull source
 RUN apt-get -y install wget
 RUN wget "https://github.com/Gregwar/fatcat/archive/${FATCAT_TARBALL}"
+RUN echo "${FATCAT_CHECKSUM} ${FATCAT_TARBALL}" | sha256sum --check
 
 RUN # Extract source tarball
 RUN tar xvf "${FATCAT_TARBALL}"
 
 RUN # Build source
 RUN apt-get -y install build-essential cmake
-RUN cmake "fatcat-${FATCAT_VERSION}" -DCMAKE_CXX_FLAGS='-static'
+RUN cmake fatcat-* -DCMAKE_CXX_FLAGS='-static'
 RUN make -j$(nproc)
 
 
@@ -63,8 +65,8 @@ LABEL maintainer="Luke Childs <lukechilds123@gmail.com>"
 ARG RPI_KERNEL_URL="https://github.com/dhruvvyas90/qemu-rpi-kernel/archive/afe411f2c9b04730bcc6b2168cdc9adca224227c.zip"
 ARG RPI_KERNEL_CHECKSUM="295a22f1cd49ab51b9e7192103ee7c917624b063cc5ca2e11434164638aad5f4"
 
-COPY --from=qemu-system-arm-builder /qemu/arm-softmmu/qemu-system-arm /usr/local/bin/qemu-system-arm
-COPY --from=qemu-system-arm-builder /qemu/aarch64-softmmu/qemu-system-aarch64 /usr/local/bin/qemu-system-aarch64
+COPY --from=qemu-builder /qemu/arm-softmmu/qemu-system-arm /usr/local/bin/qemu-system-arm
+COPY --from=qemu-builder /qemu/aarch64-softmmu/qemu-system-aarch64 /usr/local/bin/qemu-system-aarch64
 COPY --from=fatcat-builder /fatcat/fatcat /usr/local/bin/fatcat
 
 ADD $RPI_KERNEL_URL /tmp/qemu-rpi-kernel.zip

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+target="${1:-versatilepb}"
 image_path="/sdcard/filesystem.img"
 zip_path="/filesystem.zip"
 
@@ -8,22 +9,79 @@ if [ ! -e $image_path ]; then
   if [ -e $zip_path ]; then
       echo "Extracting fresh filesystem..."
       unzip $zip_path
-      mv *.img $image_path
+      mv -- *.img $image_path
   else
     exit 1
   fi
 fi
 
-exec qemu-system-arm \
-  --machine versatilepb \
+fat_path="/fat.img"
+if [ "${target}" != "versatilepb" ];
+then
+  echo "Extracting partitions"
+  fdisk -l ${image_path} \
+    | awk "/^[^ ]*1/{print \"dd if=${image_path} of=${fat_path} bs=512 skip=\"\$4\" count=\"\$6}" \
+    | sh
+fi
+if [ "${target}" = "raspi2" ];
+then
+  emulator=qemu-system-arm
+  machine=raspi2
+  memory=1024m
+  kernel_pattern=kernel7.img
+  dtb_pattern=bcm2709-rpi-2-b.dtb
+  nic=''
+elif [ "${target}" = "raspi3" ];
+then
+  emulator=qemu-system-aarch64
+  machine=raspi3
+  memory=1024m
+  kernel_pattern=kernel8.img
+  dtb_pattern=bcm2710-rpi-3-b-plus.dtb
+  nic=''
+elif [ "${target}" = "versatilepb" ];
+then
+  emulator=qemu-system-arm
+  kernel="/root/qemu-rpi-kernel/kernel-qemu-4.19.50-buster"
+  dtb="/root/qemu-rpi-kernel/versatile-pb.dtb"
+  machine=versatilepb
+  memory=256m
+  root=/dev/sda2
+  nic='--net nic --net user,hostfwd=tcp::5022-:22'
+else
+  echo "Target ${target} not supported"
+  echo "Supported targets: raspi2 raspi3 versatilepb"
+  exit 2
+fi
+
+if [ -f "${fat_path}" ];
+then
+  echo "Extracting boot filesystem"
+  fat_folder="/fat"
+  mkdir -p "${fat_folder}"
+  fatcat -x "${fat_folder}" "${fat_path}"
+  echo "Searching for kernel='${kernel_pattern}'"
+  kernel=$(find "${fat_folder}" -name "${kernel_pattern}")
+  echo "Searching for dtb='${dtb_pattern}'"
+  dtb=$(find "${fat_folder}" -name "${dtb_pattern}")
+  root=/dev/mmcblk0p2
+fi
+if [ "${kernel}" = "" ] || [ "${dtb}" = "" ];
+then
+  echo "Missing kernel='${kernel}' or dtb='${dtb}'"
+  exit 2
+fi
+
+echo "Booting with kernel=${kernel} dtb=${dtb}"
+exec ${emulator} \
+  --machine "${machine}" \
   --cpu arm1176 \
-  --m 256M \
-  --hda /sdcard/filesystem.img \
-  --net nic \
-  --net user,hostfwd=tcp::5022-:22 \
-  --dtb /root/qemu-rpi-kernel/versatile-pb.dtb \
-  --kernel /root/qemu-rpi-kernel/kernel-qemu-4.19.50-buster \
-  --append "root=/dev/sda2 panic=1" \
+  --m "${memory}" \
+  --hda "${image_path}" \
+  ${nic} \
+  --dtb "${dtb}" \
+  --kernel "${kernel}" \
+  --append "rw earlyprintk loglevel=8 console=ttyAMA0,115200 dwc_otg.lpm_enable=0 root=${root} rootwait panic=1" \
   --no-reboot \
   --display none \
   --serial mon:stdio

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-target="${1:-versatilepb}"
+target="${1:-pi1}"
 image_path="/sdcard/filesystem.img"
 zip_path="/filesystem.zip"
 
@@ -16,14 +16,14 @@ if [ ! -e $image_path ]; then
 fi
 
 fat_path="/fat.img"
-if [ "${target}" != "versatilepb" ];
+if [ "${target}" != "pi1" ];
 then
   echo "Extracting partitions"
   fdisk -l ${image_path} \
     | awk "/^[^ ]*1/{print \"dd if=${image_path} of=${fat_path} bs=512 skip=\"\$4\" count=\"\$6}" \
     | sh
 fi
-if [ "${target}" = "raspi2" ];
+if [ "${target}" = "pi2" ];
 then
   emulator=qemu-system-arm
   machine=raspi2
@@ -31,7 +31,7 @@ then
   kernel_pattern=kernel7.img
   dtb_pattern=bcm2709-rpi-2-b.dtb
   nic=''
-elif [ "${target}" = "raspi3" ];
+elif [ "${target}" = "pi3" ];
 then
   emulator=qemu-system-aarch64
   machine=raspi3
@@ -39,7 +39,7 @@ then
   kernel_pattern=kernel8.img
   dtb_pattern=bcm2710-rpi-3-b-plus.dtb
   nic=''
-elif [ "${target}" = "versatilepb" ];
+elif [ "${target}" = "pi1" ];
 then
   emulator=qemu-system-arm
   kernel="/root/qemu-rpi-kernel/kernel-qemu-4.19.50-buster"
@@ -50,7 +50,7 @@ then
   nic='--net nic --net user,hostfwd=tcp::5022-:22'
 else
   echo "Target ${target} not supported"
-  echo "Supported targets: raspi2 raspi3 versatilepb"
+  echo "Supported targets: pi1 pi2 pi3"
   exit 2
 fi
 


### PR DESCRIPTION
Support for extracting the kernel and dtb files from an SD card image to test more of an image's boot process.

1. Added 'fatcat' to extract from the boot filesystem from a standard RPI image
2. Added qemu-system-aarch64 to support raspi3 machines
3. Extracted images to search for kernel7/8.img and correct dtb files to boot kernel
4. Disabled nic for raspi2/3 as USB is not supported (yet)

Running a VM now has an optional machine target flag:

Old behaviour still supported, defaults to versatilepb with a NIC:
`docker run -it -v.../buster-lite.img:/sdcard/filesystem.img lukechilds/dockerpi:vm`

New behaviour, raspi2 and raspi3 do not have a NIC (its not yet supported):
`docker run -it -v.../buster-lite.img:/sdcard/filesystem.img lukechilds/dockerpi:vm versatilepb`
`docker run -it -v.../buster-lite.img:/sdcard/filesystem.img lukechilds/dockerpi:vm raspi2`
`docker run -it -v.../buster-lite.img:/sdcard/filesystem.img lukechilds/dockerpi:vm raspi3`

I've not updated `README.md`, if you are interested in this PR I can add some documentation.

Tested on raspian-lite, happy to test on others.