### PR TITLE
Assume raw format for image

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -74,7 +74,7 @@ exec ${emulator} \
   --machine "${machine}" \
   --cpu arm1176 \
   --m "${memory}" \
-  --hda "${image_path}" \
+  --drive "format=raw,file=${image_path}" \
   ${nic} \
   --dtb "${dtb}" \
   --kernel "${kernel}" \


### PR DESCRIPTION
This change fixes the following warning when starting a container:

```
WARNING: Image format was not specified for '/sdcard/filesystem.img' and probing guessed raw.
         Automatically detecting the format is dangerous for raw images, write operations on block 0 will be restricted.
         Specify the 'raw' format explicitly to remove the restrictions.
```