### PR TITLE
Add network support to Pi2/3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,8 +90,8 @@ ENTRYPOINT ["./entrypoint.sh"]
 # It's just the VM image with a compressed Raspbian filesystem added
 FROM dockerpi-vm as dockerpi
 LABEL maintainer="Luke Childs <lukechilds123@gmail.com>"
-ARG FILESYSTEM_IMAGE_URL="http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-09-30/2019-09-26-raspbian-buster-lite.zip"
-ARG FILESYSTEM_IMAGE_CHECKSUM="a50237c2f718bd8d806b96df5b9d2174ce8b789eda1f03434ed2213bbca6c6ff"
+ARG FILESYSTEM_IMAGE_URL="http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2020-02-14/2020-02-13-raspbian-buster-lite.zip"
+ARG FILESYSTEM_IMAGE_CHECKSUM="12ae6e17bf95b6ba83beca61e7394e7411b45eba7e6a520f434b0748ea7370e8"
 
 ADD $FILESYSTEM_IMAGE_URL /filesystem.zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage for qemu-system-arm
 FROM debian:stable-slim AS qemu-builder
-ARG QEMU_VERSION=5.2.0
+ARG QEMU_VERSION=6.0.0
 ENV QEMU_TARBALL="qemu-${QEMU_VERSION}.tar.xz"
 WORKDIR /qemu
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,8 +92,6 @@ FROM dockerpi-vm as dockerpi
 LABEL maintainer="Luke Childs <lukechilds123@gmail.com>"
 ARG FILESYSTEM_IMAGE_URL="http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-09-30/2019-09-26-raspbian-buster-lite.zip"
 ARG FILESYSTEM_IMAGE_CHECKSUM="a50237c2f718bd8d806b96df5b9d2174ce8b789eda1f03434ed2213bbca6c6ff"
-# ARG FILESYSTEM_IMAGE_URL="https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-03-25/2021-03-04-raspios-buster-armhf-lite.zip"
-# ARG FILESYSTEM_IMAGE_CHECKSUM="ea92412af99ec145438ddec3c955aa65e72ef88d84f3307cea474da005669d39"
 
 ADD $FILESYSTEM_IMAGE_URL /filesystem.zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage for qemu-system-arm
 FROM debian:stable-slim AS qemu-builder
-ARG QEMU_VERSION=4.2.0
+ARG QEMU_VERSION=5.1.0
 ENV QEMU_TARBALL="qemu-${QEMU_VERSION}.tar.xz"
 WORKDIR /qemu
 
@@ -67,6 +67,7 @@ ARG RPI_KERNEL_CHECKSUM="295a22f1cd49ab51b9e7192103ee7c917624b063cc5ca2e11434164
 
 COPY --from=qemu-builder /qemu/arm-softmmu/qemu-system-arm /usr/local/bin/qemu-system-arm
 COPY --from=qemu-builder /qemu/aarch64-softmmu/qemu-system-aarch64 /usr/local/bin/qemu-system-aarch64
+COPY --from=qemu-builder /qemu/qemu-img /usr/local/bin/qemu-img
 COPY --from=fatcat-builder /fatcat/fatcat /usr/local/bin/fatcat
 
 ADD $RPI_KERNEL_URL /tmp/qemu-rpi-kernel.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage for qemu-system-arm
 FROM debian:stable-slim AS qemu-builder
-ARG QEMU_VERSION=5.1.0
+ARG QEMU_VERSION=5.2.0
 ENV QEMU_TARBALL="qemu-${QEMU_VERSION}.tar.xz"
 WORKDIR /qemu
 
@@ -23,7 +23,7 @@ RUN tar xvf "${QEMU_TARBALL}"
 
 RUN # Build source
 # These seem to be the only deps actually required for a successful  build
-RUN apt-get -y install python build-essential libglib2.0-dev libpixman-1-dev
+RUN apt-get -y install python build-essential libglib2.0-dev libpixman-1-dev ninja-build
 # These don't seem to be required but are specified here: https://wiki.qemu.org/Hosts/Linux
 RUN apt-get -y install libfdt-dev zlib1g-dev
 # Not required or specified anywhere but supress build warnings
@@ -90,8 +90,8 @@ ENTRYPOINT ["./entrypoint.sh"]
 # It's just the VM image with a compressed Raspbian filesystem added
 FROM dockerpi-vm as dockerpi
 LABEL maintainer="Luke Childs <lukechilds123@gmail.com>"
-ARG FILESYSTEM_IMAGE_URL="http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2020-02-14/2020-02-13-raspbian-buster-lite.zip"
-ARG FILESYSTEM_IMAGE_CHECKSUM="12ae6e17bf95b6ba83beca61e7394e7411b45eba7e6a520f434b0748ea7370e8"
+ARG FILESYSTEM_IMAGE_URL="https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-03-25/2021-03-04-raspios-buster-armhf-lite.zip"
+ARG FILESYSTEM_IMAGE_CHECKSUM="ea92412af99ec145438ddec3c955aa65e72ef88d84f3307cea474da005669d39"
 
 ADD $FILESYSTEM_IMAGE_URL /filesystem.zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN "qemu-${QEMU_VERSION}/configure" --static --target-list=arm-softmmu,aarch64-
 RUN make -j$(nproc)
 
 RUN # Strip the binary, this gives a substantial size reduction!
-RUN strip "arm-softmmu/qemu-system-arm" "aarch64-softmmu/qemu-system-aarch64"
+RUN strip "arm-softmmu/qemu-system-arm" "aarch64-softmmu/qemu-system-aarch64" "qemu-img"
 
 
 # Build stage for fatcat
@@ -90,8 +90,10 @@ ENTRYPOINT ["./entrypoint.sh"]
 # It's just the VM image with a compressed Raspbian filesystem added
 FROM dockerpi-vm as dockerpi
 LABEL maintainer="Luke Childs <lukechilds123@gmail.com>"
-ARG FILESYSTEM_IMAGE_URL="https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-03-25/2021-03-04-raspios-buster-armhf-lite.zip"
-ARG FILESYSTEM_IMAGE_CHECKSUM="ea92412af99ec145438ddec3c955aa65e72ef88d84f3307cea474da005669d39"
+ARG FILESYSTEM_IMAGE_URL="http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2019-09-30/2019-09-26-raspbian-buster-lite.zip"
+ARG FILESYSTEM_IMAGE_CHECKSUM="a50237c2f718bd8d806b96df5b9d2174ce8b789eda1f03434ed2213bbca6c6ff"
+# ARG FILESYSTEM_IMAGE_URL="https://downloads.raspberrypi.org/raspios_lite_armhf/images/raspios_lite_armhf-2021-03-25/2021-03-04-raspios-buster-armhf-lite.zip"
+# ARG FILESYSTEM_IMAGE_CHECKSUM="ea92412af99ec145438ddec3c955aa65e72ef88d84f3307cea474da005669d39"
 
 ADD $FILESYSTEM_IMAGE_URL /filesystem.zip
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ docker run -it lukechilds/dockerpi pi2
 docker run -it lukechilds/dockerpi pi3
 ```
 
-> **Note:** Pi 2 and Pi 3 support is currently experimental. Networking doesn't work and QEMU hangs once the machines are powered down requiring you to `docker kill` the container. See [#4](https://github.com/lukechilds/dockerpi/pull/4) for details.
+> **Note:** In the Pi 2 and Pi 3 machines, QEMU hangs once the machines are powered down requiring you to `docker kill` the container. See [#4](https://github.com/lukechilds/dockerpi/pull/4) for details.
 
 
 ## Wait, what?

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,8 +15,6 @@ if [ ! -e $image_path ]; then
   fi
 fi
 
-qemu-img resize $image_path 4G
-
 if [ "${target}" = "pi1" ]; then
   emulator=qemu-system-arm
   kernel="/root/qemu-rpi-kernel/kernel-qemu-4.19.50-buster"
@@ -35,6 +33,13 @@ elif [ "${target}" = "pi2" ]; then
   extra='dwc_otg.fiq_fsm_enable=0'
   nic='-netdev user,id=net0,hostfwd=tcp::5022-:22 -device usb-net,netdev=net0'
 elif [ "${target}" = "pi3" ]; then
+
+  echo "Rounding image size up to a multiple of 2"
+  image_size=`du -m $image_path | cut -f1`
+  new_size=$(( ( ( image_size / 2048 ) + 1 ) * 2 ))
+  echo "from ${image_size}M to ${new_size}G"
+  qemu-img resize $image_path "${new_size}G"
+
   emulator=qemu-system-aarch64
   machine=raspi3
   memory=1024m

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,6 @@ if [ "${target}" = "pi1" ]; then
   machine=versatilepb
   memory=256m
   root=/dev/sda2
-  append=''
   nic='--net nic --net user,hostfwd=tcp::5022-:22'
 elif [ "${target}" = "pi2" ]; then
   emulator=qemu-system-arm

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,7 @@ elif [ "${target}" = "pi2" ]; then
   kernel_pattern=kernel7.img
   dtb_pattern=bcm2709-rpi-2-b.dtb
   extra='dwc_otg.fiq_fsm_enable=0'
-  nic='-netdev user,id=net0 -device usb-net,netdev=net0'
+  nic='-netdev user,id=net0,hostfwd=tcp::5022-:22 -device usb-net,netdev=net0'
 elif [ "${target}" = "pi3" ]; then
   emulator=qemu-system-aarch64
   machine=raspi3
@@ -41,7 +41,7 @@ elif [ "${target}" = "pi3" ]; then
   kernel_pattern=kernel8.img
   dtb_pattern=bcm2710-rpi-3-b-plus.dtb
   extra='dwc_otg.fiq_fsm_enable=0'
-  nic='-netdev user,id=net0 -device usb-net,netdev=net0'
+  nic='-netdev user,id=net0,hostfwd=tcp::5022-:22 -device usb-net,netdev=net0'
 else
   echo "Target ${target} not supported"
   echo "Supported targets: pi1 pi2 pi3"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,7 @@ if [ "${target}" = "pi1" ]; then
   machine=versatilepb
   memory=256m
   root=/dev/sda2
-  extra=''
+  append=''
   nic='--net nic --net user,hostfwd=tcp::5022-:22'
 elif [ "${target}" = "pi2" ]; then
   emulator=qemu-system-arm
@@ -37,7 +37,7 @@ elif [ "${target}" = "pi2" ]; then
   memory=1024m
   kernel_pattern=kernel7.img
   dtb_pattern=bcm2709-rpi-2-b.dtb
-  extra='dwc_otg.fiq_fsm_enable=0'
+  append='dwc_otg.fiq_fsm_enable=0'
   nic='-netdev user,id=net0,hostfwd=tcp::5022-:22 -device usb-net,netdev=net0'
 elif [ "${target}" = "pi3" ]; then
   emulator=qemu-system-aarch64
@@ -45,7 +45,7 @@ elif [ "${target}" = "pi3" ]; then
   memory=1024m
   kernel_pattern=kernel8.img
   dtb_pattern=bcm2710-rpi-3-b-plus.dtb
-  extra='dwc_otg.fiq_fsm_enable=0'
+  append='dwc_otg.fiq_fsm_enable=0'
   nic='-netdev user,id=net0,hostfwd=tcp::5022-:22 -device usb-net,netdev=net0'
 else
   echo "Target ${target} not supported"
@@ -88,7 +88,7 @@ exec ${emulator} \
   ${nic} \
   --dtb "${dtb}" \
   --kernel "${kernel}" \
-  --append "rw earlyprintk loglevel=8 console=ttyAMA0,115200 dwc_otg.lpm_enable=0 root=${root} rootwait panic=1 ${extra}" \
+  --append "rw earlyprintk loglevel=8 console=ttyAMA0,115200 dwc_otg.lpm_enable=0 root=${root} rootwait panic=1 ${append}" \
   --no-reboot \
   --display none \
   --serial mon:stdio

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,8 @@ if [ ! -e $image_path ]; then
   fi
 fi
 
+qemu-img resize 4G
+
 if [ "${target}" = "pi1" ]; then
   emulator=qemu-system-arm
   kernel="/root/qemu-rpi-kernel/kernel-qemu-4.19.50-buster"
@@ -22,6 +24,7 @@ if [ "${target}" = "pi1" ]; then
   machine=versatilepb
   memory=256m
   root=/dev/sda2
+  extra=''
   nic='--net nic --net user,hostfwd=tcp::5022-:22'
 elif [ "${target}" = "pi2" ]; then
   emulator=qemu-system-arm
@@ -29,14 +32,16 @@ elif [ "${target}" = "pi2" ]; then
   memory=1024m
   kernel_pattern=kernel7.img
   dtb_pattern=bcm2709-rpi-2-b.dtb
-  nic=''
+  extra='dwc_otg.fiq_fsm_enable=0'
+  nic='-netdev user,id=net0 -device usb-net,netdev=net0'
 elif [ "${target}" = "pi3" ]; then
   emulator=qemu-system-aarch64
   machine=raspi3
   memory=1024m
   kernel_pattern=kernel8.img
   dtb_pattern=bcm2710-rpi-3-b-plus.dtb
-  nic=''
+  extra='dwc_otg.fiq_fsm_enable=0'
+  nic='-netdev user,id=net0 -device usb-net,netdev=net0'
 else
   echo "Target ${target} not supported"
   echo "Supported targets: pi1 pi2 pi3"
@@ -78,7 +83,7 @@ exec ${emulator} \
   ${nic} \
   --dtb "${dtb}" \
   --kernel "${kernel}" \
-  --append "rw earlyprintk loglevel=8 console=ttyAMA0,115200 dwc_otg.lpm_enable=0 root=${root} rootwait panic=1" \
+  --append "rw earlyprintk loglevel=8 console=ttyAMA0,115200 dwc_otg.lpm_enable=0 root=${root} rootwait panic=1 ${extra}" \
   --no-reboot \
   --display none \
   --serial mon:stdio

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,6 +15,13 @@ if [ ! -e $image_path ]; then
   fi
 fi
 
+echo "Rounding image size up to a multiple of 2G"
+image_size=`du -m $image_path | cut -f1`
+new_size=$(( ( ( image_size / 2048 ) + 1 ) * 2 ))
+echo "from ${image_size}M to ${new_size}G"
+qemu-img resize $image_path "${new_size}G"
+
+
 if [ "${target}" = "pi1" ]; then
   emulator=qemu-system-arm
   kernel="/root/qemu-rpi-kernel/kernel-qemu-4.19.50-buster"
@@ -26,22 +33,15 @@ if [ "${target}" = "pi1" ]; then
   nic='--net nic --net user,hostfwd=tcp::5022-:22'
 elif [ "${target}" = "pi2" ]; then
   emulator=qemu-system-arm
-  machine=raspi2
+  machine=raspi2b
   memory=1024m
   kernel_pattern=kernel7.img
   dtb_pattern=bcm2709-rpi-2-b.dtb
   extra='dwc_otg.fiq_fsm_enable=0'
   nic='-netdev user,id=net0,hostfwd=tcp::5022-:22 -device usb-net,netdev=net0'
 elif [ "${target}" = "pi3" ]; then
-
-  echo "Rounding image size up to a multiple of 2G"
-  image_size=`du -m $image_path | cut -f1`
-  new_size=$(( ( ( image_size / 2048 ) + 1 ) * 2 ))
-  echo "from ${image_size}M to ${new_size}G"
-  qemu-img resize $image_path "${new_size}G"
-
   emulator=qemu-system-aarch64
-  machine=raspi3
+  machine=raspi3b
   memory=1024m
   kernel_pattern=kernel8.img
   dtb_pattern=bcm2710-rpi-3-b-plus.dtb

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ elif [ "${target}" = "pi2" ]; then
   nic='-netdev user,id=net0,hostfwd=tcp::5022-:22 -device usb-net,netdev=net0'
 elif [ "${target}" = "pi3" ]; then
 
-  echo "Rounding image size up to a multiple of 2"
+  echo "Rounding image size up to a multiple of 2G"
   image_size=`du -m $image_path | cut -f1`
   new_size=$(( ( ( image_size / 2048 ) + 1 ) * 2 ))
   echo "from ${image_size}M to ${new_size}G"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,23 +29,23 @@ if [ "${target}" = "pi1" ]; then
   machine=versatilepb
   memory=256m
   root=/dev/sda2
-  nic='--net nic --net user,hostfwd=tcp::5022-:22'
+  nic="--net nic --net user,hostfwd=tcp::5022-:22"
 elif [ "${target}" = "pi2" ]; then
   emulator=qemu-system-arm
   machine=raspi2b
   memory=1024m
   kernel_pattern=kernel7.img
   dtb_pattern=bcm2709-rpi-2-b.dtb
-  append='dwc_otg.fiq_fsm_enable=0'
-  nic='-netdev user,id=net0,hostfwd=tcp::5022-:22 -device usb-net,netdev=net0'
+  append="dwc_otg.fiq_fsm_enable=0"
+  nic="-netdev user,id=net0,hostfwd=tcp::5022-:22 -device usb-net,netdev=net0"
 elif [ "${target}" = "pi3" ]; then
   emulator=qemu-system-aarch64
   machine=raspi3b
   memory=1024m
   kernel_pattern=kernel8.img
   dtb_pattern=bcm2710-rpi-3-b-plus.dtb
-  append='dwc_otg.fiq_fsm_enable=0'
-  nic='-netdev user,id=net0,hostfwd=tcp::5022-:22 -device usb-net,netdev=net0'
+  append="dwc_otg.fiq_fsm_enable=0"
+  nic="-netdev user,id=net0,hostfwd=tcp::5022-:22 -device usb-net,netdev=net0"
 else
   echo "Target ${target} not supported"
   echo "Supported targets: pi1 pi2 pi3"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,7 +15,7 @@ if [ ! -e $image_path ]; then
   fi
 fi
 
-qemu-img resize 4G
+qemu-img resize $image_path 4G
 
 if [ "${target}" = "pi1" ]; then
   emulator=qemu-system-arm


### PR DESCRIPTION
Also include most of the changes needed for Qemu 5.1 from #20 as needed for USB support (with the resize increased to 4G and moved to apply to passed in images as well as the included one).

Should have the included image updated to match latest at time of release.

Device comes up as usb0 but close enough to get started.

I did test with Qemu 5.2-rc3 to see if Pi4 support was included but doesn't look like it yet.