### PR TITLE
Push all tags to DockerHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Login to Docker Hub
         run: echo "${{secrets.DOCKER_TOKEN}}" | docker login -u=lukechilds --password-stdin
       - name: Push to Docker Hub
-        run: docker push lukechilds/dockerpi
+        run: docker push --all-tags lukechilds/dockerpi


### PR DESCRIPTION
The behavior behind `docker push` changed in the last year or two. The original behavior was that all tags associated with a particular Image would be pushed together. The new behavior is that only the `latest` tag is pushed. To replicate the old behavior, you need to specify the `--all-tags` flag.

Without this change, the next Github Action run will only push `dockerpi:latest` to Dockerhub. It'll skip `dockerpi:vm`.

Notes and discussion on the change are here: https://github.com/docker/cli/issues/2214
