### PR TITLE
Add possibility to forward custom ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ docker run -it lukechilds/dockerpi pi3
 
 In some applications you may want to have access to some ports of the Raspberry Pi (e.g. for SSH connection). To do so, you can set the `QEMU_HOSTFWD` enviroment variable of the container by adding one or more entries, separated by spaces, in the standard QEMU format (`protocol::hostip:hostport-guestip:guestport`).
 
-Example using the `docker run` command to expose the SSH port from the Raspberry Pi to the Container (`-e` part) and from the Container to the Host (`-p` part):
+Example using the `docker run` command to expose the SSH and MQTT ports from the Raspberry Pi to the Container (`-e` part) and from the Container to the Host (`-p` part):
 
 ```
-docker run -it -e QEMU_HOSTFWD=tcp::5022-:22 -p 5022:5022 lukechilds/dockerpi
+docker run -it -e QEMU_HOSTFWD="tcp::5022-:22 tcp::1883-:1883" -p 5022:5022 -p 1883:1883 lukechilds/dockerpi
 ```
 
 Example using the `docker-compose.yml` file to achieve the same result:
@@ -79,9 +79,10 @@ services:
   dockerpi:
     image: lukechilds/dockerpi
     environment:
-     - QEMU_HOSTFWD=tcp::5022-:22
+     - QEMU_HOSTFWD=tcp::5022-:22 tcp::1883-:1883
     ports:
      - "5022:5022"
+     - "1883:1883"
 ```
 
 ## Wait, what?

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ docker run -it lukechilds/dockerpi pi3
 
 ## Port forwarding
 
-In some applications you may want to have access to some ports of the Raspberry Pi (e.g. for SSH connection). To do so, you can set the `HOSTFWD` enviroment variable of the container by adding one or more entries, separated by spaces, in the standard QEMU format (`protocol::hostip:hostport-guestip:guestport`).
+In some applications you may want to have access to some ports of the Raspberry Pi (e.g. for SSH connection). To do so, you can set the `QEMU_HOSTFWD` enviroment variable of the container by adding one or more entries, separated by spaces, in the standard QEMU format (`protocol::hostip:hostport-guestip:guestport`).
 
 Example using the `docker run` command to expose the SSH port from the Raspberry Pi to the Container (`-e` part) and from the Container to the Host (`-p` part):
 
 ```
-docker run -it -e HOSTFWD=tcp::5022-:22 -p 5022:5022 lukechilds/dockerpi
+docker run -it -e QEMU_HOSTFWD=tcp::5022-:22 -p 5022:5022 lukechilds/dockerpi
 ```
 
 Example using the `docker-compose.yml` file to achieve the same result:
@@ -79,7 +79,7 @@ services:
   dockerpi:
     image: lukechilds/dockerpi
     environment:
-     - HOSTFWD=tcp::5022-:22
+     - QEMU_HOSTFWD=tcp::5022-:22
     ports:
      - "5022:5022"
 ```

--- a/README.md
+++ b/README.md
@@ -62,6 +62,27 @@ docker run -it lukechilds/dockerpi pi3
 
 > **Note:** In the Pi 2 and Pi 3 machines, QEMU hangs once the machines are powered down requiring you to `docker kill` the container. See [#4](https://github.com/lukechilds/dockerpi/pull/4) for details.
 
+## Port forwarding
+
+In some applications you may want to have access to some ports of the Raspberry Pi (e.g. for SSH connection). To do so, you can set the `HOSTFWD` enviroment variable of the container by adding one or more entries, separated by spaces, in the standard QEMU format (`protocol::hostip:hostport-guestip:guestport`).
+
+Example using the `docker run` command to expose the SSH port from the Raspberry Pi to the Container (`-e` part) and from the Container to the Host (`-p` part):
+
+```
+docker run -it -e HOSTFWD=tcp::5022-:22 -p 5022:5022 lukechilds/dockerpi
+```
+
+Example using the `docker-compose.yml` file to achieve the same result:
+
+```yml
+services:
+  dockerpi:
+    image: lukechilds/dockerpi
+    environment:
+     - HOSTFWD=tcp::5022-:22
+    ports:
+     - "5022:5022"
+```
 
 ## Wait, what?
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ if [[ "$(($image_size_in_bytes % ($GIB_IN_BYTES * 2)))" != "0" ]]; then
   qemu-img resize $image_path "${new_size_in_gib}G"
 fi
 
-for fwd in $HOSTFWD; do hostfwd="$hostfwd,hostfwd=$fwd"; done
+for fwd in $QEMU_HOSTFWD; do hostfwd="$hostfwd,hostfwd=$fwd"; done
 
 if [ "${target}" = "pi1" ]; then
   emulator=qemu-system-arm

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,6 +33,7 @@ if [ "${target}" = "pi1" ]; then
   memory=256m
   root=/dev/sda2
   nic="--net nic --net user,hostfwd=tcp::5022-:22"
+  for fwd in $HOSTFWD; do nic="$nic,hostfwd=$fwd"; done
 elif [ "${target}" = "pi2" ]; then
   emulator=qemu-system-arm
   machine=raspi2b
@@ -40,7 +41,9 @@ elif [ "${target}" = "pi2" ]; then
   kernel_pattern=kernel7.img
   dtb_pattern=bcm2709-rpi-2-b.dtb
   append="dwc_otg.fiq_fsm_enable=0"
-  nic="-netdev user,id=net0,hostfwd=tcp::5022-:22 -device usb-net,netdev=net0"
+  nic="-netdev user,id=net0,hostfwd=tcp::5022-:22"
+  for fwd in $HOSTFWD; do nic="$nic,hostfwd=$fwd"; done
+  nic="$nic -device usb-net,netdev=net0"
 elif [ "${target}" = "pi3" ]; then
   emulator=qemu-system-aarch64
   machine=raspi3b
@@ -48,7 +51,9 @@ elif [ "${target}" = "pi3" ]; then
   kernel_pattern=kernel8.img
   dtb_pattern=bcm2710-rpi-3-b-plus.dtb
   append="dwc_otg.fiq_fsm_enable=0"
-  nic="-netdev user,id=net0,hostfwd=tcp::5022-:22 -device usb-net,netdev=net0"
+  nic="-netdev user,id=net0,hostfwd=tcp::5022-:22"
+  for fwd in $HOSTFWD; do nic="$nic,hostfwd=$fwd"; done
+  nic="$nic -device usb-net,netdev=net0"
 else
   echo "Target ${target} not supported"
   echo "Supported targets: pi1 pi2 pi3"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,8 @@ if [[ "$(($image_size_in_bytes % ($GIB_IN_BYTES * 2)))" != "0" ]]; then
   qemu-img resize $image_path "${new_size_in_gib}G"
 fi
 
+for fwd in $HOSTFWD; do hostfwd="$hostfwd,hostfwd=$fwd"; done
+
 if [ "${target}" = "pi1" ]; then
   emulator=qemu-system-arm
   kernel="/root/qemu-rpi-kernel/kernel-qemu-4.19.50-buster"
@@ -32,8 +34,7 @@ if [ "${target}" = "pi1" ]; then
   machine=versatilepb
   memory=256m
   root=/dev/sda2
-  nic="--net nic --net user,hostfwd=tcp::5022-:22"
-  for fwd in $HOSTFWD; do nic="$nic,hostfwd=$fwd"; done
+  nic="--net nic --net user$hostfwd"
 elif [ "${target}" = "pi2" ]; then
   emulator=qemu-system-arm
   machine=raspi2b
@@ -41,9 +42,7 @@ elif [ "${target}" = "pi2" ]; then
   kernel_pattern=kernel7.img
   dtb_pattern=bcm2709-rpi-2-b.dtb
   append="dwc_otg.fiq_fsm_enable=0"
-  nic="-netdev user,id=net0,hostfwd=tcp::5022-:22"
-  for fwd in $HOSTFWD; do nic="$nic,hostfwd=$fwd"; done
-  nic="$nic -device usb-net,netdev=net0"
+  nic="-netdev user,id=net0$hostfwd -device usb-net,netdev=net0"
 elif [ "${target}" = "pi3" ]; then
   emulator=qemu-system-aarch64
   machine=raspi3b
@@ -51,9 +50,7 @@ elif [ "${target}" = "pi3" ]; then
   kernel_pattern=kernel8.img
   dtb_pattern=bcm2710-rpi-3-b-plus.dtb
   append="dwc_otg.fiq_fsm_enable=0"
-  nic="-netdev user,id=net0,hostfwd=tcp::5022-:22"
-  for fwd in $HOSTFWD; do nic="$nic,hostfwd=$fwd"; done
-  nic="$nic -device usb-net,netdev=net0"
+  nic="-netdev user,id=net0$hostfwd -device usb-net,netdev=net0"
 else
   echo "Target ${target} not supported"
   echo "Supported targets: pi1 pi2 pi3"


### PR DESCRIPTION
> [!IMPORTANT]
> Since the maintainer of this repository is no longer actively maintaining it, I'm hosting a custom-built image with this feature added at [`ghcr.io/matteocarnelos/dockerpi`](https://ghcr.io/matteocarnelos/dockerpi).
>
> If you wish to use this feature before it gets merged (if it will ever get merged at all), replace all instances of `lukechilds/dockerpi` with `ghcr.io/matteocarnelos/dockerpi`.

I've added the possibility to forward custom ports (besides the SSH one) by setting the environment variable `HOSTFWD`.

This is particularly useful when using applications with a web interface (Grafana, InfluxDB, RaspAP,...) inside the emulated Raspberry Pi, or when using protocols such as MQTT, FTP,....

### Usage
Add one or more entries in the standard QEMU format (`protocol::hostip:hostport-guestip:guestport`) separated by spaces.

Example using the `docker run` command to expose the MQTT port from the Raspberry Pi to the Container (`-e` part) and from the Container to the Host (`-p` part):
```
docker run -it -e HOSTFWD=tcp::1883-:1883 -p 1883:1883 lukechilds/dockerpi 
```

Example using the `docker-compose.yml` file to achieve the same as above:
```yml
services:
  dockerpi:
    image: lukechilds/dockerpi
    ports:
     - "1883:1883"
    environment:
     - HOSTFWD=tcp::1883-:1883
```