### PR TITLE
Update BusyBox base image to v1.34

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN make -j$(nproc)
 
 
 # Build the dockerpi VM image
-FROM busybox:1.31 AS dockerpi-vm
+FROM busybox:1.34 AS dockerpi-vm
 LABEL maintainer="Luke Childs <lukechilds123@gmail.com>"
 ARG RPI_KERNEL_URL="https://github.com/dhruvvyas90/qemu-rpi-kernel/archive/afe411f2c9b04730bcc6b2168cdc9adca224227c.zip"
 ARG RPI_KERNEL_CHECKSUM="295a22f1cd49ab51b9e7192103ee7c917624b063cc5ca2e11434164638aad5f4"


### PR DESCRIPTION
This version of BusyBox contains a fix to an issue uncompressing OS image zip files larger than 4GB: https://busybox.net
> unzip: fix for .zip archives with >4GB file

In my workflow I expand the OS image and when the file ends up bigger than 4GB it shows this zip error message and waits for user input:
```
$ docker run -it -v my_image.zip:/sdcard/filesystem.zip lukechilds/dockerpi:vm
No filesystem detected at /sdcard/filesystem.img!
Extracting fresh filesystem...
Archive:  /filesystem.zip
  inflating: 2021-05-07-raspios-buster-armhf-lite-autologin-ssh-expanded.img
unzip: bad length
replace 2021-05-07-raspios-buster-armhf-lite-autologin-ssh-expanded.img? [y]es, [n]o, [A]ll, [N]one, [r]ename:
```

After selecting and option it does work correctly, but waiting for user input is a problem for running these containers in CI.

Using the latest BusyBox fixes this and it uncompresses the zip file without these problems.