### PR TITLE
Dockerfile: install xz-utils before extracting QEMU (closes #56)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN gpg --keyserver keyserver.ubuntu.com --recv-keys CEACC9E15534EBABB82D3FA0335
 RUN gpg --verify "${QEMU_TARBALL}.sig" "${QEMU_TARBALL}"
 
 RUN # Extract source tarball
-RUN apt-get -y install pkg-config
+RUN apt-get -y install pkg-config xz-utils
 RUN tar xvf "${QEMU_TARBALL}"
 
 RUN # Build source


### PR DESCRIPTION
I'm getting the same error as in #56 running on Ubuntu 22.04 locally.

Installing `zx-utils` fixes #56.