### PR TITLE
Dockerfile: EXPOSE 5022 (ssh)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,7 @@ RUN cd /tmp && \
     rm -rf /tmp/*
 
 VOLUME /sdcard
+EXPOSE 5022
 
 ADD ./entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
Let docker know that we expose a service on port 5022.